### PR TITLE
refactor: revise response data processing

### DIFF
--- a/src/wrapped-fetch.js
+++ b/src/wrapped-fetch.js
@@ -107,6 +107,7 @@ export default class WrappedFetch {
         .then(response => {
           copy = response.clone();
           copy.useCache = useCache;
+
           if (charset === 'gbk') {
             try {
               return response
@@ -116,15 +117,17 @@ export default class WrappedFetch {
             } catch (e) {
               throw new ResponseError(copy, e.message);
             }
-          } else if (responseType === 'json' || responseType === 'text') {
+          }
+
+          if (responseType === 'json') {
             return response.text().then(safeJsonParse);
-          } else {
-            try {
-              // 其他如blob, arrayBuffer, formData
-              return response[responseType]();
-            } catch (e) {
-              throw new ResponseError(copy, 'responseType not support');
-            }
+          }
+
+          try {
+            // 其他如 text, blob, arrayBuffer, formData
+            return response[responseType]();
+          } catch (e) {
+            throw new ResponseError(copy, 'responseType not support');
           }
         })
         .then(data => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -94,6 +94,27 @@ describe('test fetch:', () => {
     });
     expect(response.a).toBe(11);
 
+    response = await request(prefix('/test/responseType'), {
+      method: 'post',
+      responseType: 'text',
+      data: { a: 12 },
+    });
+    expect(typeof response === 'string').toBe(true);
+
+    response = await request(prefix('/test/responseType'), {
+      method: 'post',
+      responseType: 'formData',
+      data: { a: 13 },
+    });
+    expect(response instanceof FormData).toBe(true);
+
+    response = await request(prefix('/test/responseType'), {
+      method: 'post',
+      responseType: 'arrayBuffer',
+      data: { a: 14 },
+    });
+    expect(response instanceof ArrayBuffer).toBe(true);
+
     try {
       response = await request(prefix('/test/responseType'), {
         responseType: 'other',


### PR DESCRIPTION
当设置了 ` responseType = text` 的时候，应该直接返回 ` response.text() `，而不是尝试 JSON Parse