### PR TITLE
feat: added response filter & tests

### DIFF
--- a/src/wrapped-fetch.js
+++ b/src/wrapped-fetch.js
@@ -100,7 +100,7 @@ export default class WrappedFetch {
    * @param {boolean} useCache 返回类型, 默认json
    */
   _parseResponse(instance, useCache = false) {
-    const { responseType = 'json', charset = 'utf8', getResponse = false } = this.options;
+    const { responseType = 'json', charset = 'utf8', getResponse = false, responseFilter } = this.options;
     return new Promise((resolve, reject) => {
       let copy;
       instance
@@ -135,6 +135,8 @@ export default class WrappedFetch {
                 data,
                 response: copy,
               });
+            } else if (typeof responseFilter === 'function') {
+              resolve(responseFilter(data));
             } else {
               resolve(data);
             }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -327,6 +327,32 @@ describe('test fetch:', () => {
     expect(response.data[1]).toBe('2');
   });
 
+  it('test response filter', async () => {
+    server.get('/api/test-response-filter/success', (req, res) => {
+      writeData({ success: true, data: 123 }, res);
+    });
+
+    server.get('/api/test-response-filter/error', (req, res) => {
+      writeData({ success: false, errorCode: 321 }, res);
+    });
+
+    const responseFilter = data => {
+      if (data.success) {
+        return data.data;
+      }
+      return data.errorCode;
+    };
+
+    const extendRequest = extend({
+      responseFilter,
+    });
+    const successResponse = await extendRequest(prefix('/api/test-response-filter/success'));
+    const errorResponse = await extendRequest(prefix('/api/test-response-filter/error'));
+    console.log('successResponse', successResponse);
+    expect(successResponse).toBe(123);
+    expect(errorResponse).toBe(321);
+  });
+
   afterAll(() => {
     server.close();
   });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,6 +29,7 @@ export interface RequestOptionsInit extends RequestInit {
   ttl?: number;
   timeout?: number;
   errorHandler?: (error: ResponseError) => void;
+  responseFilter?: (response: any) => any;
   prefix?: string;
   suffix?: string;
 }


### PR DESCRIPTION
Added a feature that enables user to pass in a user defined `responseFilter` function in request init option. 

This function allows user to:
1. post-process response data so they won't need to deal with it after each call of `request`. 
2. not struggle with writing another wrapper around the request instance & lose `request`'s syntactic sugar (i.e. .get .post ...)