### PR TITLE
fix: support fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jest": "^23.5.0",
     "np": "5.0.2",
     "typescript": "^3.0.3",
-    "umi": "^2.5.0",
+    "umi": "^2.8.15",
     "umi-lint": "^1.0.0-alpha.1",
     "umi-plugin-library": "^1.1.6",
     "umi-test": "^1.4.0"

--- a/src/core.js
+++ b/src/core.js
@@ -1,15 +1,8 @@
 import Onion from './onion/onion';
 import { MapCache } from './utils';
-import fetchMiddleware from './middleware/fetch';
-import addfixMiddleware from './middleware/addfix';
-import parseResponseMiddleware from './middleware/parseResponse';
-import simplePost from './middleware/simplePost';
-import simpleGet from './middleware/simpleGet';
-
-const defaultMiddlewares = [addfixMiddleware, simplePost, simpleGet, fetchMiddleware, parseResponseMiddleware];
 
 class Core {
-  constructor(initOptions) {
+  constructor(initOptions, defaultMiddlewares) {
     this.onion = new Onion(defaultMiddlewares);
     this.mapCache = new MapCache(initOptions);
     this.requestInterceptors = [];

--- a/src/core.js
+++ b/src/core.js
@@ -1,8 +1,9 @@
 import Onion from './onion/onion';
 import { MapCache } from './utils';
+import addfixInterceptor from './interceptor/addfix';
 
 // 旧版拦截器为共享
-const requestInterceptors = [];
+const requestInterceptors = [addfixInterceptor];
 const responseInterceptors = [];
 
 class Core {
@@ -26,7 +27,8 @@ class Core {
     responseInterceptors.push(handler);
   }
 
-  static beforeRequest(ctx) {
+  // 执行请求前拦截器
+  static dealRequestInterceptors(ctx) {
     const reducer = (p1, p2) =>
       p1.then((ret = {}) => {
         ctx.req.url = ret.url || ctx.req.url;
@@ -53,7 +55,7 @@ class Core {
     }
 
     return new Promise((resolve, reject) => {
-      Core.beforeRequest(obj)
+      Core.dealRequestInterceptors(obj)
         .then(() => onion.execute(obj))
         .then(() => {
           resolve(obj.res);

--- a/src/core.js
+++ b/src/core.js
@@ -1,12 +1,14 @@
 import Onion from './onion/onion';
 import { MapCache } from './utils';
 
+// 旧版拦截器为共享
+const requestInterceptors = [];
+const responseInterceptors = [];
+
 class Core {
   constructor(initOptions, defaultMiddlewares) {
     this.onion = new Onion(defaultMiddlewares);
     this.mapCache = new MapCache(initOptions);
-    this.requestInterceptors = [];
-    this.responseInterceptors = [];
   }
 
   use(newMiddleware) {
@@ -14,24 +16,24 @@ class Core {
     return this;
   }
 
-  requestUse(handler) {
+  static requestUse(handler) {
     if (typeof handler !== 'function') throw new TypeError('Interceptor must be function!');
-    this.requestInterceptors.push(handler);
+    requestInterceptors.push(handler);
   }
 
-  responseUse(handler) {
+  static responseUse(handler) {
     if (typeof handler !== 'function') throw new TypeError('Interceptor must be function!');
-    this.responseInterceptors.push(handler);
+    responseInterceptors.push(handler);
   }
 
-  beforeRequest(ctx) {
+  static beforeRequest(ctx) {
     const reducer = (p1, p2) =>
       p1.then((ret = {}) => {
         ctx.req.url = ret.url || ctx.req.url;
         ctx.req.options = ret.options || ctx.req.options;
         return p2(ctx.req.url, ctx.req.options);
       });
-    return this.requestInterceptors.reduce(reducer, Promise.resolve()).then((ret = {}) => {
+    return requestInterceptors.reduce(reducer, Promise.resolve()).then((ret = {}) => {
       ctx.req.url = ret.url || ctx.req.url;
       ctx.req.options = ret.options || ctx.req.options;
       return Promise.resolve();
@@ -39,7 +41,7 @@ class Core {
   }
 
   request(url, options) {
-    const { onion, responseInterceptors } = this;
+    const { onion } = this;
     const obj = {
       req: { url, options },
       res: null,
@@ -51,7 +53,7 @@ class Core {
     }
 
     return new Promise((resolve, reject) => {
-      this.beforeRequest(obj)
+      Core.beforeRequest(obj)
         .then(() => onion.execute(obj))
         .then(() => {
           resolve(obj.res);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-import request, { extend } from './request';
+import request, { extend, fetch } from './request';
 import Onion from './onion/onion';
 import { RequestError, ResponseError } from './utils';
 
-export { extend, RequestError, ResponseError, Onion };
+export { extend, RequestError, ResponseError, Onion, fetch };
 export default request;

--- a/src/interceptor/addfix.js
+++ b/src/interceptor/addfix.js
@@ -1,0 +1,14 @@
+// 前后缀拦截器
+export default (url, options = {}) => {
+  const { prefix, suffix } = options;
+  if (prefix) {
+    url = `${prefix}${url}`;
+  }
+  if (suffix) {
+    url = `${url}${suffix}`;
+  }
+  return {
+    url,
+    options,
+  };
+};

--- a/src/request.js
+++ b/src/request.js
@@ -1,6 +1,5 @@
 import Core from './core';
 import fetchMiddleware from './middleware/fetch';
-import addfixMiddleware from './middleware/addfix';
 import parseResponseMiddleware from './middleware/parseResponse';
 import simplePost from './middleware/simplePost';
 import simpleGet from './middleware/simpleGet';
@@ -55,7 +54,7 @@ const request = (initOptions = {}, middleware = []) => {
  * @param {function} errorHandler 统一错误处理方法
  * @param {object} headers 统一的headers
  */
-const _extendMiddlewares = [addfixMiddleware, simplePost, simpleGet, fetchMiddleware, parseResponseMiddleware];
+const _extendMiddlewares = [simplePost, simpleGet, fetchMiddleware, parseResponseMiddleware];
 export const extend = initOptions => request(initOptions, _extendMiddlewares);
 
 /**

--- a/src/request.js
+++ b/src/request.js
@@ -31,10 +31,10 @@ const request = (initOptions = {}, middleware = []) => {
   // 拦截器
   umiInstance.interceptors = {
     request: {
-      use: coreInstance.requestUse.bind(coreInstance),
+      use: Core.requestUse,
     },
     response: {
-      use: coreInstance.responseUse.bind(coreInstance),
+      use: Core.responseUse,
     },
   };
 

--- a/src/request.js
+++ b/src/request.js
@@ -17,7 +17,7 @@ const request = (initOptions = {}, middleware = []) => {
         ...options.headers,
       },
       params: {
-        ...initOptions.headers,
+        ...initOptions.params,
         ...options.params,
       },
       method: (options.method || 'get').toLowerCase(),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -701,9 +701,8 @@ describe('test fetch middleware:', () => {
 
     // request拦截器, 加个参数
     fetch.interceptors.request.use((url, options) => {
-      debug(url, options);
       return {
-        url: `${url}?interceptors=yes`,
+        url: `${url}&fetch=fetch`,
         options: { ...options, interceptors: true },
       };
     });
@@ -715,19 +714,20 @@ describe('test fetch middleware:', () => {
     });
 
     let response = await fetch(prefix('/test/interceptors'));
-    expect(response.headers.get('interceptors')).toBe('yes yo');
+    expect(response.headers.get('interceptors')).toBe('yes yo,yes yo');
     const resText = await response.text();
+    expect(JSON.parse(resText).fetch).toBe('fetch');
 
-    expect(JSON.parse(resText).interceptors).toBe('yes');
     request.interceptors = fetch.interceptors;
-    response = await request(prefix('/test/interceptors'));
     request.interceptors.request.use((url, options) => {
       return {
         url: `${url}&foo=foo`,
         options,
       };
     });
-    expect(response.interceptors).toBe('yes');
+
+    response = await request(prefix('/test/interceptors'));
+    expect(response.fetch).toBe('fetch');
     expect(response.foo).toBe('foo');
   }, 3000);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -213,6 +213,7 @@ describe('test fetch:', () => {
       maxCache: 2,
       prefix: server.url,
       headers: { Connection: 'keep-alive' },
+      params: { defaultParams: true },
     });
 
     // 第一次写入缓存
@@ -273,6 +274,7 @@ describe('test fetch:', () => {
     });
 
     expect(response.response.useCache).toBe(false);
+    expect(response.data.defaultParams).toBe('true');
   }, 10000);
 
   // 测试异常捕获


### PR DESCRIPTION
1. 修复 fetch api 被隐藏的问题，补充 fetch 对应测试样例；
2. 修复fetch、request 不共享拦截器的问题，补充对应测试样例；
3. 修复 extend 函数入参 params 失效问题， 补充对应测试样例；
4. 修复前后缀逻辑处于请求前拦截器后的问题；