### PR TITLE
fix: remove properties `credentials` in interface `RequestOptionsInit`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,7 +31,6 @@ export interface RequestOptionsInit extends RequestInit {
   errorHandler?: (error: ResponseError) => void;
   prefix?: string;
   suffix?: string;
-  credentials?: string;
 }
 
 export interface RequestOptionsWithoutResponse extends RequestOptionsInit {


### PR DESCRIPTION
credentials has declared in `RequestInit`, remove in `RequestOptionsInit`.