### PR TITLE
fix: update properties 'next' in interface 'OnionMiddleware'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -66,7 +66,7 @@ export interface Context {
 
 export type ResponseInterceptor = (response: Response, options: RequestOptionsInit) => Response | Promise<Response>;
 
-export type OnionMiddleware = (ctx: Context, next: NextCallback) => void;
+export type OnionMiddleware = (ctx: Context, next: () => void) => void;
 
 export interface RequestMethod<R = false> {
   <T = any>(url: string, options: RequestOptionsWithResponse): Promise<RequestResponse<T>>;


### PR DESCRIPTION
property 'next' was undefined before, update 'next' to '() => void' in interface 'OnionMiddleware'.