### PR TITLE
feat: add-dealResponseInterceptors

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -56,6 +56,15 @@ class Core {
     });
   }
 
+  // 执行响应后拦截器
+  static dealResponseInterceptors(ctx) {
+    const reducer = (p1, p2) =>
+      p1.then((ret = {}) => {
+        return p2(ret, ctx.req.options);
+      });
+    return responseInterceptors.reduce(reducer, Promise.resolve()).then(() => Promise.resolve());
+  }
+
   request(url, options) {
     const { onion } = this;
     const obj = {
@@ -71,6 +80,8 @@ class Core {
     return new Promise((resolve, reject) => {
       Core.dealRequestInterceptors(obj)
         .then(() => onion.execute(obj))
+
+      Core.dealResponseInterceptors(obj)
         .then(() => {
           resolve(obj.res);
         })


### PR DESCRIPTION
umi-request现在无法在`responseInterceptor`变更response的Promise状态，这导致一些需求无法实现：

在`responseInterceptor`将一个`status: 200`的响应，设为rejected状态。

