### PR TITLE
feat: 添加abort controller 取消请求

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The network request library, based on fetch encapsulation, combines the features
 [![Build Status](https://img.shields.io/travis/umijs/umi-request.svg?style=flat)](https://travis-ci.org/umijs/umi-request)
 [![NPM downloads](http://img.shields.io/npm/dm/umi-request.svg?style=flat)](https://npmjs.org/package/umi-request)
 
---------------------
+---
 
 ## Supported features
 
@@ -26,22 +26,22 @@ The network request library, based on fetch encapsulation, combines the features
 
 ## umi-request vs fetch vs axios
 
-| Features | umi-request | fetch | axios |
-| :---------- | :-------------- | :-------------- | :-------------- |
-| implementation | Browser native support | Browser native support | XMLHttpRequest |
-| size | 9k | 4k (polyfill) | 14k |
-| query simplification | ✅ | ❌ | ✅ |
-| post simplification | ✅ | ❌ | ❌ |
-| timeout | ✅ | ❌ | ✅ |
-| cache | ✅ | ❌ | ❌ |
-| error Check | ✅ | ❌ | ❌ |
-| error Handling | ✅ | ❌ | ✅ |
-| interceptor | ✅ | ❌ | ✅ |
-| prefix | ✅ | ❌ | ❌ |
-| suffix | ✅ | ❌ | ❌ |
-| processing gbk | ✅ | ❌ | ❌ |
-| middleware | ✅ | ❌ | ❌ |
-| cancel request | ✅ | ❌ | ✅ |
+| Features             | umi-request            | fetch                  | axios          |
+| :------------------- | :--------------------- | :--------------------- | :------------- |
+| implementation       | Browser native support | Browser native support | XMLHttpRequest |
+| size                 | 9k                     | 4k (polyfill)          | 14k            |
+| query simplification | ✅                     | ❌                     | ✅             |
+| post simplification  | ✅                     | ❌                     | ❌             |
+| timeout              | ✅                     | ❌                     | ✅             |
+| cache                | ✅                     | ❌                     | ❌             |
+| error Check          | ✅                     | ❌                     | ❌             |
+| error Handling       | ✅                     | ❌                     | ✅             |
+| interceptor          | ✅                     | ❌                     | ✅             |
+| prefix               | ✅                     | ❌                     | ❌             |
+| suffix               | ✅                     | ❌                     | ❌             |
+| processing gbk       | ✅                     | ❌                     | ❌             |
+| middleware           | ✅                     | ❌                     | ❌             |
+| cancel request       | ✅                     | ❌                     | ✅             |
 
 For more discussion, refer to [Traditional Ajax is dead, Fetch eternal life](https://github.com/camsong/blog/issues/2) If you have good suggestions and needs, please mention [issue](https://github.com/umijs/umi/issues)
 
@@ -60,52 +60,56 @@ npm install --save umi-request
 ```
 
 ## Example
-Performing a ```GET``` request
 
-``` javascript
+Performing a `GET` request
+
+```javascript
 import request from 'umi-request';
 
-request.get('/api/v1/xxx?id=1')
-  .then(function (response) {
+request
+  .get('/api/v1/xxx?id=1')
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 
 // use options.params
-request.get('/api/v1/xxx', {
+request
+  .get('/api/v1/xxx', {
     params: {
-      id: 1
-    }
+      id: 1,
+    },
   })
-  .then(function (response) {
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 ```
 
-Performing a ```POST``` request
+Performing a `POST` request
 
-``` javascript
-request.post('/api/v1/user', {
+```javascript
+request
+  .post('/api/v1/user', {
     data: {
-      name: 'Mike'
-    }
+      name: 'Mike',
+    },
   })
-  .then(function (response) {
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 ```
 
 ## umi-request API
 
-Requests can be made by passing relevant options to ```umi-request```
+Requests can be made by passing relevant options to `umi-request`
 
 **umi-request(url[, options])**
 
@@ -113,29 +117,28 @@ Requests can be made by passing relevant options to ```umi-request```
 import request from 'umi-request';
 
 request('/api/v1/xxx', {
-    method: 'get',
-    params: { id: 1 }
-  })
-  .then(function (response) {
+  method: 'get',
+  params: { id: 1 },
+})
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 
 request('/api/v1/user', {
-    method: 'post',
-    data: {
-      name: 'Mike'
-    }
-  })
-  .then(function (response) {
+  method: 'post',
+  data: {
+    name: 'Mike',
+  },
+})
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
-
 ```
 
 ## Request method aliases
@@ -158,26 +161,27 @@ For convenience umi-request have been provided for all supported methods.
 
 ## Creating an instance
 
-You can use ```extend({[options]})``` to create a new instance of umi-request.
+You can use `extend({[options]})` to create a new instance of umi-request.
 
 **extend([options])**
 
-``` javascript
+```javascript
 import { extend } from 'umi-request';
 
 const request = extend({
   prefix: '/api/v1',
   timeout: 1000,
   headers: {
-    'Content-Type': 'multipart/form-data'
-  }
+    'Content-Type': 'multipart/form-data',
+  },
 });
 
-request.get('/user')
-  .then(function (response) {
+request
+  .get('/user')
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 ```
@@ -186,7 +190,7 @@ Create an instance of umi-request in NodeJS enviroment
 
 ```javascript
 const umi = require('umi-request');
-const extendRequest = umi.extend({ timeout: 10000 })
+const extendRequest = umi.extend({ timeout: 10000 });
 
 extendRequest('/api/user')
   .then(res => {
@@ -217,41 +221,41 @@ More umi-request cases can see [antd-pro](https://github.com/umijs/ant-design-pr
 
 ## request options
 
-| Parameter | Description | Type | Optional Value | Default |
-| :--- | :--- | :--- | :--- | :--- |
-| method | request method | string | get , post , put ... | get |
-| params | url request parameters | object or URLSearchParams | -- | -- |
-| data | Submitted data | any | -- | -- |
-| headers | fetch original parameters | object | -- | {} |
-| timeout | timeout, default millisecond, write with caution | number | -- | -- |
-| prefix | prefix, generally used to override the uniform settings prefix | string | -- | -- |
-| suffix | suffix, such as some scenes api need to be unified .json | string | -- |
-| credentials | fetch request with cookies | string | -- | credentials: 'same-origin' |
-| useCache | Whether to use caching (only support browser environment) | boolean | -- | false |
-| validateCache | cache strategy function | (url, options) => boolean | -- | only get request to cache |
-| ttl | Cache duration, 0 is not expired | number | -- | 60000 |
-| maxCache | Maximum number of caches | number | -- | 0(Infinity) |
-| requestType | post request data type | string | json , form | json |
-| parseResponse | response processing simplification | boolean | -- | true |
-| charset | character set | string | utf8 , gbk | utf8 |
-| responseType | How to parse the returned data | string | json , text , blob , formData ... | json , text |
-| throwErrIfParseFail | throw error when JSON parse fail and responseType is 'json' | boolean | -- | false |
-| getResponse | Whether to get the source response, the result will wrap a layer | boolean | -- | fasle |
-| errorHandler | exception handling, or override unified exception handling | function(error) | -- |
-| cancelToken | Token to cancel request | CancelToken.token | -- | -- |
+| Parameter           | Description                                                      | Type                      | Optional Value                    | Default                    |
+| :------------------ | :--------------------------------------------------------------- | :------------------------ | :-------------------------------- | :------------------------- |
+| method              | request method                                                   | string                    | get , post , put ...              | get                        |
+| params              | url request parameters                                           | object or URLSearchParams | --                                | --                         |
+| data                | Submitted data                                                   | any                       | --                                | --                         |
+| headers             | fetch original parameters                                        | object                    | --                                | {}                         |
+| timeout             | timeout, default millisecond, write with caution                 | number                    | --                                | --                         |
+| prefix              | prefix, generally used to override the uniform settings prefix   | string                    | --                                | --                         |
+| suffix              | suffix, such as some scenes api need to be unified .json         | string                    | --                                |
+| credentials         | fetch request with cookies                                       | string                    | --                                | credentials: 'same-origin' |
+| useCache            | Whether to use caching (only support browser environment)        | boolean                   | --                                | false                      |
+| validateCache       | cache strategy function                                          | (url, options) => boolean | --                                | only get request to cache  |
+| ttl                 | Cache duration, 0 is not expired                                 | number                    | --                                | 60000                      |
+| maxCache            | Maximum number of caches                                         | number                    | --                                | 0(Infinity)                |
+| requestType         | post request data type                                           | string                    | json , form                       | json                       |
+| parseResponse       | response processing simplification                               | boolean                   | --                                | true                       |
+| charset             | character set                                                    | string                    | utf8 , gbk                        | utf8                       |
+| responseType        | How to parse the returned data                                   | string                    | json , text , blob , formData ... | json , text                |
+| throwErrIfParseFail | throw error when JSON parse fail and responseType is 'json'      | boolean                   | --                                | false                      |
+| getResponse         | Whether to get the source response, the result will wrap a layer | boolean                   | --                                | fasle                      |
+| errorHandler        | exception handling, or override unified exception handling       | function(error)           | --                                |
+| cancelToken         | Token to cancel request                                          | CancelToken.token         | --                                | --                         |
 
 The other parameters of fetch are valid. See [fetch documentation](https://github.github.io/fetch/)
 
 ## extend options Initialize default parameters, support all of the above
 
-| Parameter | Description | Type | Optional Value | Default |
-| :--- | :--- | :--- | :--- | :--- |
-| method | request method | string | get , post , put ... | get |
-| params | url request parameters | object | -- | -- |
-| data | Submitted data | any | -- | -- |
-| ... |
+| Parameter | Description            | Type   | Optional Value       | Default |
+| :-------- | :--------------------- | :----- | :------------------- | :------ |
+| method    | request method         | string | get , post , put ... | get     |
+| params    | url request parameters | object | --                   | --      |
+| data      | Submitted data         | any    | --                   | --      |
+| ...       |
 
-``` javascript
+```javascript
 {
   // 'method' is the request method to be used when making the request
   method: 'get', // default
@@ -324,7 +328,7 @@ The other parameters of fetch are valid. See [fetch documentation](https://githu
   //   ...options.headers,
   // }
   // options.body = JSON.stringify(data)
-  // 
+  //
   // 2. requestType === 'form':
   // options.headers = {
   //   Accept: 'application/json',
@@ -332,7 +336,7 @@ The other parameters of fetch are valid. See [fetch documentation](https://githu
   //   ...options.headers,
   // };
   // options.body = query-string.stringify(data);
-  // 
+  //
   // 3. other requestType
   // options.headers = {
   //   Accept: 'application/json',
@@ -341,7 +345,7 @@ The other parameters of fetch are valid. See [fetch documentation](https://githu
   // options.body = data;
   requestType: 'json', // default
 
-  // 'parseResponse' whether processing response 
+  // 'parseResponse' whether processing response
   parseResponse: true, // default
 
   // 'charset' This parameter can be used when the server returns gbk to avoid garbled characters.(parseResponse should set to true)
@@ -367,13 +371,14 @@ The other parameters of fetch are valid. See [fetch documentation](https://githu
 ```
 
 ### Extend Options
+
 Sometimes we need to update options after **extend** a request instance, umi-request provide **extendOptions** for users to update options:
 
 ```javascript
-const request = extend({ timeout: 1000, params: { a: '1' }})
+const request = extend({ timeout: 1000, params: { a: '1' } });
 // default options is: { timeout: 1000, params: { a: '1' }}
 
-request.extendOptions({ timeout: 3000, params: { b: '2' }})
+request.extendOptions({ timeout: 3000, params: { b: '2' } });
 // after extendOptions: { timeout: 3000, params: { a: '1', b: '2' }}
 ```
 
@@ -381,7 +386,7 @@ request.extendOptions({ timeout: 3000, params: { b: '2' }})
 
 The response for a request contains the following information.
 
-``` javascript
+```javascript
 {
   // 'data' is the response that was provided by the server
   data: {},
@@ -400,34 +405,31 @@ The response for a request contains the following information.
 
 When options.getResponse === false, the response schema would be 'data'
 
-``` javascript
-request.get('/api/v1/xxx', { getResponse: false })
-  .then(function(data) {
-    console.log(data);
-  })
+```javascript
+request.get('/api/v1/xxx', { getResponse: false }).then(function(data) {
+  console.log(data);
+});
 ```
 
 When options.getResponse === true ，the response schema would be { data, response }
 
-``` javascript
-request.get('/api/v1/xxx', { getResponse: true })
-  .then(function({ data, response }) {
-    console.log(data);
-    console.log(response.status);
-    console.log(response.statusText);
-    console.log(response.headers);
-  })
-
+```javascript
+request.get('/api/v1/xxx', { getResponse: true }).then(function({ data, response }) {
+  console.log(data);
+  console.log(response.status);
+  console.log(response.statusText);
+  console.log(response.headers);
+});
 ```
 
-You can get Response from ```error``` object in errorHandler or request.catch.
+You can get Response from `error` object in errorHandler or request.catch.
 
 ## Error handling
 
 ```javascript
 import request, { extend } from 'umi-request';
 
-const errorHandler = function (error) {
+const errorHandler = function(error) {
   const codeMap = {
     '021': 'An error has occurred',
     '022': 'It’s a big mistake,',
@@ -440,17 +442,17 @@ const errorHandler = function (error) {
     console.log(error.response.headers);
     console.log(error.data);
     console.log(error.request);
-    console.log(codeMap[error.data.status])
+    console.log(codeMap[error.data.status]);
   } else {
     // The request was made but no response was received or error occurs when setting up the request.
     console.log(error.message);
   }
 
   throw error; // If throw. The error will continue to be thrown.
-  
+
   // return {some: 'data'}; If return, return the value as a return. If you don't write it is equivalent to return undefined, you can judge whether the response has a value when processing the result.
-  // return {some: 'data'}; 
-}
+  // return {some: 'data'};
+};
 
 // 1. Unified processing
 const extendRequest = extend({ errorHandler });
@@ -459,15 +461,14 @@ const extendRequest = extend({ errorHandler });
 // If unified processing is configured, but an api needs special handling. When requested, the errorHandler is passed as a parameter.
 request('/api/v1/xxx', { errorHandler });
 
-
 // 3. not configure errorHandler, the response will be directly treated as promise, and it will be caught.
 request('/api/v1/xxx')
-.then(function (response) {
-  console.log(response);
-})
-.catch(function (error) {
-  return errorHandler(error);
-})
+  .then(function(response) {
+    console.log(response);
+  })
+  .catch(function(error) {
+    return errorHandler(error);
+  });
 ```
 
 ## Middleware
@@ -484,30 +485,30 @@ request.use(fn[, options])
 
 fn params
 
-* ctx(Object)：context, content request and response
-* next(Function)：function to call the next middleware
+- ctx(Object)：context, content request and response
+- next(Function)：function to call the next middleware
 
 options params
 
-* global(boolean): whether global， higher priority than core
-* core(boolean): whether core
+- global(boolean): whether global， higher priority than core
+- core(boolean): whether core
 
 ### example
 
 1. same type of middlewares
 
-``` javascript
+```javascript
 import request, { extend } from 'umi-request';
 request.use(async (ctx, next) => {
   console.log('a1');
   await next();
   console.log('a2');
-})
+});
 request.use(async (ctx, next) => {
   console.log('b1');
   await next();
   console.log('b2');
-})
+});
 
 const data = await request('/api/v1/a');
 ```
@@ -520,27 +521,33 @@ a1 -> b1 -> response -> b2 -> a2
 
 2. Defferent type of middlewares
 
-``` javascript
-request.use( async (ctx, next) => {
+```javascript
+request.use(async (ctx, next) => {
   console.log('instanceA1');
   await next();
   console.log('instanceA2');
-})
-request.use( async (ctx, next) => {
+});
+request.use(async (ctx, next) => {
   console.log('instanceB1');
   await next();
   console.log('instanceB2');
-})
-request.use( async (ctx, next) => {
-  console.log('globalA1');
-  await next();
-  console.log('globalA2');
-}, { global: true })
-request.use( async (ctx, next) => {
-  console.log('coreA1');
-  await next();
-  console.log('coreA2');
-}, { core: true })
+});
+request.use(
+  async (ctx, next) => {
+    console.log('globalA1');
+    await next();
+    console.log('globalA2');
+  },
+  { global: true }
+);
+request.use(
+  async (ctx, next) => {
+    console.log('coreA1');
+    await next();
+    console.log('coreA2');
+  },
+  { core: true }
+);
 ```
 
 order of middlewares be called:
@@ -551,67 +558,66 @@ instanceA1 -> instanceB1 -> globalA1 -> coreA1 -> coreA2 -> globalA2 -> instance
 
 3. Enhance request
 
-``` javascript
+```javascript
 request.use(async (ctx, next) => {
   const { req } = ctx;
   const { url, options } = req;
 
-  if ( url.indexOf('/api') !== 0 ) {
+  if (url.indexOf('/api') !== 0) {
     ctx.req.url = `/api/v1/${url}`;
   }
   ctx.req.options = {
     ...options,
-    foo: 'foo'
+    foo: 'foo',
   };
 
   await next();
 
   const { res } = ctx;
-  const { success = false } = res; 
+  const { success = false } = res;
   if (!success) {
     // ...
   }
-})
-
+});
 ```
 
 4. Use core middleware to expand request core.
 
-``` javascript
+```javascript
+request.use(
+  async (ctx, next) => {
+    const { req } = ctx;
+    const { url, options } = req;
+    const { __umiRequestCoreType__ = 'normal' } = options;
 
-request.use(async (ctx, next) => {
-  const { req } = ctx;
-  const { url, options } = req;
-  const { __umiRequestCoreType__ = 'normal' } = options;
-  
-  // __umiRequestCoreType__ use to identificat request core
-  // when value is 'normal' , use umi-request 's fetch request core
-  if ( __umiRequestCoreType__ === 'normal') {
+    // __umiRequestCoreType__ use to identificat request core
+    // when value is 'normal' , use umi-request 's fetch request core
+    if (__umiRequestCoreType__ === 'normal') {
+      await next();
+      return;
+    }
+
+    // when value is not normal, use your request func.
+    const response = getResponseByOtherWay();
+
+    ctx.res = response;
+
     await next();
     return;
-  }
-
-  // when value is not normal, use your request func. 
-  const response = getResponseByOtherWay();
-
-  ctx.res = response;
-
-  await next();
-  return;
-}, { core: true });
-
+  },
+  { core: true }
+);
 
 request('/api/v1/rpc', {
   __umiRequestCoreType__: 'rpc',
   parseResponse: false,
 })
-  .then(function (response) {
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
-  })
-
+  });
 ```
 
 ## Interceptor
@@ -620,26 +626,25 @@ You can intercept requests or responses before they are handled by then or catch
 
 1. global Interceptor
 
-``` javascript
+```javascript
 // request interceptor, change url or options.
 request.interceptors.request.use((url, options) => {
-  return (
-    {
-      url: `${url}&interceptors=yes`,
-      options: { ...options, interceptors: true },
-    }
-  );
+  return {
+    url: `${url}&interceptors=yes`,
+    options: { ...options, interceptors: true },
+  };
 });
 
 // Same as the last one
-request.interceptors.request.use((url, options) => {
-  return (
-    {
+request.interceptors.request.use(
+  (url, options) => {
+    return {
       url: `${url}&interceptors=yes`,
       options: { ...options, interceptors: true },
-    }
-  );
-}, { global: true });
+    };
+  },
+  { global: true }
+);
 
 // response interceptor, chagne response
 request.interceptors.response.use((response, options) => {
@@ -648,7 +653,7 @@ request.interceptors.response.use((response, options) => {
 });
 
 // handling error in response interceptor
-request.interceptors.response.use((response) => {
+request.interceptors.response.use(response => {
   const codeMaps = {
     502: '网关错误。',
     503: '服务不可用，服务器暂时过载或维护。',
@@ -659,29 +664,32 @@ request.interceptors.response.use((response) => {
 });
 
 // clone response in response interceptor
-request.interceptors.response.use(async (response) => {
+request.interceptors.response.use(async response => {
   const data = await response.clone().json();
-  if(data && data.NOT_LOGIN) {
+  if (data && data.NOT_LOGIN) {
     location.href = '登录url';
   }
   return response;
-})
+});
 ```
 
 1. instance Interceptor
 
-``` javascript
+```javascript
 // Global interceptors are used `request` instance method directly
-request.interceptors.request.use((url, options) => {
-  return {
-    url: `${url}&interceptors=yes`,
-    options: { ...options, interceptors: true },
-  };
-}, { global: false }); // second paramet defaults { global: true }
+request.interceptors.request.use(
+  (url, options) => {
+    return {
+      url: `${url}&interceptors=yes`,
+      options: { ...options, interceptors: true },
+    };
+  },
+  { global: false }
+); // second paramet defaults { global: true }
 
 function createClient(baseUrl) {
   const request = extend({
-    prefix: baseUrl
+    prefix: baseUrl,
   });
   return request;
 }
@@ -689,19 +697,25 @@ function createClient(baseUrl) {
 const clientA = createClient('/api');
 const clientB = createClient('/api');
 // Independent instance Interceptor
-clientA.interceptors.request.use((url, options) => {
-  return {
-    url: `${url}&interceptors=clientA`,
-    options,
-  };
-}, { global: false });
+clientA.interceptors.request.use(
+  (url, options) => {
+    return {
+      url: `${url}&interceptors=clientA`,
+      options,
+    };
+  },
+  { global: false }
+);
 
-clientB.interceptors.request.use((url, options) => {
-  return {
-    url: `${url}&interceptors=clientB`,
-    options,
-  };
-}, { global: false });
+clientB.interceptors.request.use(
+  (url, options) => {
+    return {
+      url: `${url}&interceptors=clientB`,
+      options,
+    };
+  },
+  { global: false }
+);
 ```
 
 ## Cancel request
@@ -715,7 +729,7 @@ const CancelToken = Request.CancelToken;
 const { token, cancel } = CancelToken.source();
 
 Request.get('/api/cancel', {
-  cancelToken: token
+  cancelToken: token,
 }).catch(function(thrown) {
   if (Request.isCancel(thrown)) {
     console.log('Request canceled', thrown.message);
@@ -724,17 +738,22 @@ Request.get('/api/cancel', {
   }
 });
 
-Request.post('/api/cancel', {
-  name: 'hello world'
-}, {
-  cancelToken: token
-})
+Request.post(
+  '/api/cancel',
+  {
+    name: 'hello world',
+  },
+  {
+    cancelToken: token,
+  }
+);
 
 // cancel request (the message parameter is optional)
 cancel('Operation canceled by the user.');
 ```
 
 2. You can also create a cancel token by passing an executor function to the CancelToken constructor:
+
 ```javascript
 import Request from 'umi-request';
 
@@ -744,11 +763,32 @@ let cancel;
 Request.get('/api/cancel', {
   cancelToken: new CancelToken(function executor(c) {
     cancel = c;
-  })
+  }),
 });
 
 // cancel request
 cancel();
+```
+
+3. create AbortCOntroller cancel
+
+```javascript
+import Request, { AbortController } from 'umi-request';
+
+const controller = new AbortController();
+const { signal } = controller;
+
+signal.addEventListener('abort', () => {
+  console.log('aborted!');
+});
+
+Request('http://127.0.0.1:3009/', {
+  signal,
+});
+// 取消请求
+setTimeout(() => {
+  controller.abort();
+}, 1000);
 ```
 
 ## Cases
@@ -757,23 +797,22 @@ cancel();
 
 Use **Headers.get()** (more detail see [MDN 文档](https://developer.mozilla.org/zh-CN/docs/Web/API/Headers/get))
 
-``` javascript
-request('/api/v1/some/api', { getResponse: true })
-.then(({ data, response}) => {
+```javascript
+request('/api/v1/some/api', { getResponse: true }).then(({ data, response }) => {
   response.headers.get('Content-Type');
-})
+});
 ```
 
 If want to get a custem header, you need to set [Access-Control-Expose-Headers](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) on server.
 
 ### File upload
 
-Use FormData() contructor，the browser will add rerequest header  ```"Content-Type: multipart/form-data"``` automatically, developer don't need to add request header **Content-Type**
+Use FormData() contructor，the browser will add rerequest header `"Content-Type: multipart/form-data"` automatically, developer don't need to add request header **Content-Type**
 
-``` javascript
+```javascript
 const formData = new FormData();
 formData.append('file', file);
-request('/api/v1/some/api', { method:'post', data: formData });
+request('/api/v1/some/api', { method: 'post', data: formData });
 ```
 
 The Access-Control-Expose-Headers response header indicates which headers can be exposed as part of the response by listing their names.[Access-Control-Expose-Headers](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -2,7 +2,7 @@
 
 # umi-request
 
-网络请求库，基于 fetch 封装, 兼具 fetch 与 axios 的特点, 旨在为开发者提供一个统一的api调用方式, 简化使用, 并提供诸如缓存, 超时, 字符编码处理, 错误处理等常用功能.
+网络请求库，基于 fetch 封装, 兼具 fetch 与 axios 的特点, 旨在为开发者提供一个统一的 api 调用方式, 简化使用, 并提供诸如缓存, 超时, 字符编码处理, 错误处理等常用功能.
 
 [![NPM version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
@@ -12,7 +12,7 @@
 [travis-image]: https://img.shields.io/travis/umijs/umi-request.svg?style=flat-square
 [travis-url]: https://travis-ci.org/umijs/umi-request.svg?branch=master
 
---------------------
+---
 
 ## 支持的功能
 
@@ -31,76 +31,82 @@
 ## 与 fetch, axios 异同
 
 | 特性       | umi-request    | fetch          | axios          |
-| :---------- | :-------------- | :-------------- | :-------------- |
+| :--------- | :------------- | :------------- | :------------- |
 | 实现       | 浏览器原生支持 | 浏览器原生支持 | XMLHttpRequest |
 | 大小       | 9k             | 4k (polyfill)  | 14k            |
-| query 简化 | ✅              | ❌              | ✅              |
-| post 简化  | ✅              | ❌              | ❌              |
-| 超时       | ✅              | ❌              | ✅              |
-| 缓存       | ✅              | ❌              | ❌              |
-| 错误检查   | ✅              | ❌              | ❌              |
-| 错误处理   | ✅              | ❌              | ✅              |
-| 拦截器     | ✅              | ❌              | ✅              |
-| 前缀       | ✅              | ❌              | ❌              |
-| 后缀       | ✅              | ❌              | ❌              |
-| 处理 gbk   | ✅              | ❌              | ❌              |
-| 中间件     | ✅              | ❌              | ❌              |
-| 取消请求   | ✅              | ❌              | ✅              |
+| query 简化 | ✅             | ❌             | ✅             |
+| post 简化  | ✅             | ❌             | ❌             |
+| 超时       | ✅             | ❌             | ✅             |
+| 缓存       | ✅             | ❌             | ❌             |
+| 错误检查   | ✅             | ❌             | ❌             |
+| 错误处理   | ✅             | ❌             | ✅             |
+| 拦截器     | ✅             | ❌             | ✅             |
+| 前缀       | ✅             | ❌             | ❌             |
+| 后缀       | ✅             | ❌             | ❌             |
+| 处理 gbk   | ✅             | ❌             | ❌             |
+| 中间件     | ✅             | ❌             | ❌             |
+| 取消请求   | ✅             | ❌             | ✅             |
 
 更多讨论参考[传统 Ajax 已死，Fetch 永生](https://github.com/camsong/blog/issues/2), 如果你有好的建议和需求, 请提 [issue](https://github.com/umijs/umi/issues)
 
-## TODO 欢迎pr
+## TODO 欢迎 pr
 
-- [x] 测试用例覆盖85%+
+- [x] 测试用例覆盖 85%+
 - [x] 写文档
-- [x] CI集成
+- [x] CI 集成
 - [x] 发布配置
 - [x] typescript
 
 ## 安装
+
 ```
 npm install --save umi-request
 ```
 
 ## 快速上手
+
 执行 **GET** 请求
 
-``` javascript
+```javascript
 import request from 'umi-request';
 
-request.get('/api/v1/xxx?id=1')
-  .then(function (response) {
+request
+  .get('/api/v1/xxx?id=1')
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 
 // 也可将 URL 的参数放到 options.params 里
-request.get('/api/v1/xxx', {
+request
+  .get('/api/v1/xxx', {
     params: {
-      id: 1
-    }
+      id: 1,
+    },
   })
-  .then(function (response) {
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 ```
 
 执行 **POST** 请求
-``` javascript
-request.post('/api/v1/user', {
+
+```javascript
+request
+  .post('/api/v1/user', {
     data: {
-      name: 'Mike'
-    }
+      name: 'Mike',
+    },
   })
-  .then(function (response) {
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 ```
@@ -110,38 +116,38 @@ request.post('/api/v1/user', {
 可以通过向 **umi-request** 传参来发起请求
 
 **umi-request(url[, options])**
+
 ```javascript
 import request from 'umi-request';
 
 request('/api/v1/xxx', {
-    method: 'get',
-    params: { id: 1 }
-  })
-  .then(function (response) {
+  method: 'get',
+  params: { id: 1 },
+})
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 
 request('/api/v1/user', {
-    method: 'post',
-    data: {
-      name: 'Mike'
-    }
-  })
-  .then(function (response) {
+  method: 'post',
+  data: {
+    name: 'Mike',
+  },
+})
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
-
 ```
 
 ## 请求方法的别名
 
-为了方便起见，为所有支持的请求方法提供了别名, ```method``` 属性不必在配置中指定
+为了方便起见，为所有支持的请求方法提供了别名, `method` 属性不必在配置中指定
 
 **request.get(url[, options])**
 
@@ -159,26 +165,27 @@ request('/api/v1/user', {
 
 ## 创建实例
 
-有些通用的配置我们不想每个请求里都去添加，那么可以通过 ```extend``` 新建一个 umi-request 实例
+有些通用的配置我们不想每个请求里都去添加，那么可以通过 `extend` 新建一个 umi-request 实例
 
 **extend([options])**
 
-``` javascript
+```javascript
 import { extend } from 'umi-request';
 
 const request = extend({
   prefix: '/api/v1',
   timeout: 1000,
   headers: {
-    'Content-Type': 'multipart/form-data'
-  }
+    'Content-Type': 'multipart/form-data',
+  },
 });
 
-request.get('/user')
-  .then(function (response) {
+request
+  .get('/user')
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
   });
 ```
@@ -187,7 +194,7 @@ NodeJS 环境创建实例
 
 ```javascript
 const umi = require('umi-request');
-const extendRequest = umi.extend({ timeout: 10000 })
+const extendRequest = umi.extend({ timeout: 10000 });
 
 extendRequest('/api/user')
   .then(res => {
@@ -197,7 +204,6 @@ extendRequest('/api/user')
     console.log(err);
   });
 ```
-
 
 以下是可用的实例方法，指定的配置将与实例的配置合并。
 
@@ -215,49 +221,47 @@ extendRequest('/api/user')
 
 **request.options(url[, options])**
 
-
 umi-request 可以进行一层简单封装后再使用, 可参考 [antd-pro](https://github.com/umijs/ant-design-pro/blob/master/src/utils/request.js)
-
 
 ## 请求配置
 
 ### request options 参数
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-| :---  | :---  | :---  | :---  | :---  |
-| method | 请求方式 | string | get , post , put ... | get |
-| params | url请求参数 | object 或 URLSearchParams 对象 | -- | -- |
-| data | 提交的数据 | any | -- | -- |
-| headers | fetch 原有参数 | object | -- | {} |
-| timeout | 超时时长, 默认毫秒, 写操作慎用  | number | -- | -- |
-| prefix | 前缀, 一般用于覆盖统一设置的prefix | string | -- | -- |
-| suffix | 后缀, 比如某些场景 api 需要统一加 .json  | string | -- | -- |
-| credentials | fetch 请求包含 cookies 信息 | string | -- | credentials: 'same-origin' |
-| useCache | 是否使用缓存（仅支持浏览器客户端） | boolean | -- | false |
-| validateCache | 缓存策略函数 | (url, options) => boolean | -- | 默认 get 请求做缓存 |
-| ttl | 缓存时长, 0 为不过期 | number | -- | 60000 |
-| maxCache | 最大缓存数 | number | -- | 无限 |
-| requestType | post请求时数据类型 | string | json , form | json |
-| parseResponse | 是否对 response 做处理简化 | boolean | -- | true |
-| charset | 字符集 | string | utf8 , gbk | utf8 |
-| responseType | 如何解析返回的数据 | string | json , text , blob , formData ... | json , text |
-| throwErrIfParseFail | 当 responseType 为 'json', 对请求结果做 JSON.parse 出错时是否抛出异常 | boolean | -- |false |
-| getResponse | 是否获取源response, 返回结果将包裹一层 | boolean | -- | fasle |
-| errorHandler | 异常处理, 或者覆盖统一的异常处理 | function(error) | -- |
-| cancelToken | 取消请求的 Token | CancelToken.token | -- | -- |
+| 参数                | 说明                                                                  | 类型                           | 可选值                            | 默认值                     |
+| :------------------ | :-------------------------------------------------------------------- | :----------------------------- | :-------------------------------- | :------------------------- |
+| method              | 请求方式                                                              | string                         | get , post , put ...              | get                        |
+| params              | url 请求参数                                                          | object 或 URLSearchParams 对象 | --                                | --                         |
+| data                | 提交的数据                                                            | any                            | --                                | --                         |
+| headers             | fetch 原有参数                                                        | object                         | --                                | {}                         |
+| timeout             | 超时时长, 默认毫秒, 写操作慎用                                        | number                         | --                                | --                         |
+| prefix              | 前缀, 一般用于覆盖统一设置的 prefix                                   | string                         | --                                | --                         |
+| suffix              | 后缀, 比如某些场景 api 需要统一加 .json                               | string                         | --                                | --                         |
+| credentials         | fetch 请求包含 cookies 信息                                           | string                         | --                                | credentials: 'same-origin' |
+| useCache            | 是否使用缓存（仅支持浏览器客户端）                                    | boolean                        | --                                | false                      |
+| validateCache       | 缓存策略函数                                                          | (url, options) => boolean      | --                                | 默认 get 请求做缓存        |
+| ttl                 | 缓存时长, 0 为不过期                                                  | number                         | --                                | 60000                      |
+| maxCache            | 最大缓存数                                                            | number                         | --                                | 无限                       |
+| requestType         | post 请求时数据类型                                                   | string                         | json , form                       | json                       |
+| parseResponse       | 是否对 response 做处理简化                                            | boolean                        | --                                | true                       |
+| charset             | 字符集                                                                | string                         | utf8 , gbk                        | utf8                       |
+| responseType        | 如何解析返回的数据                                                    | string                         | json , text , blob , formData ... | json , text                |
+| throwErrIfParseFail | 当 responseType 为 'json', 对请求结果做 JSON.parse 出错时是否抛出异常 | boolean                        | --                                | false                      |
+| getResponse         | 是否获取源 response, 返回结果将包裹一层                               | boolean                        | --                                | fasle                      |
+| errorHandler        | 异常处理, 或者覆盖统一的异常处理                                      | function(error)                | --                                |
+| cancelToken         | 取消请求的 Token                                                      | CancelToken.token              | --                                | --                         |
 
-fetch原其他参数有效, 详见[fetch文档](https://github.github.io/fetch/)
+fetch 原其他参数有效, 详见[fetch 文档](https://github.github.io/fetch/)
 
 ### extend options 初始化默认参数, 支持以上所有
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 |
-| :---  | :---  | :---  | :---  | :---  |
-| method | 请求方式 | string | get , post , put ... | get |
-| params | url请求参数 | object | -- | -- |
-| data | 提交的数据 | any | -- | -- |
-| ... |
+| 参数   | 说明         | 类型   | 可选值               | 默认值 |
+| :----- | :----------- | :----- | :------------------- | :----- |
+| method | 请求方式     | string | get , post , put ... | get    |
+| params | url 请求参数 | object | --                   | --     |
+| data   | 提交的数据   | any    | --                   | --     |
+| ...    |
 
-``` javascript
+```javascript
 {
   // 'method' 是创建请求时使用的方法
   method: 'get', // default
@@ -366,19 +370,18 @@ fetch原其他参数有效, 详见[fetch文档](https://github.github.io/fetch/)
 实例化一个请求实例后，有时还需要动态更新默认参数，umi-request 提供 **extendOptions** 方法供用户进行更新：
 
 ```javascript
-const request = extend({ timeout: 1000, params: { a: '1' }})
+const request = extend({ timeout: 1000, params: { a: '1' } });
 // 默认参数是 { timeout: 1000, params: { a: '1' }}
 
-request.extendOptions({ timeout: 3000, params: { b: '2' }})
+request.extendOptions({ timeout: 3000, params: { b: '2' } });
 // 此时默认参数是 { timeout: 3000, params: { a: '1', b: '2' }}
-
 ```
 
 ## 响应结构
 
 某个请求的响应返回的响应对象 Response 如下：
 
-``` javascript
+```javascript
 {
   // `data` 由服务器提供的响应, 需要进行解析才能获取
   data: {},
@@ -396,34 +399,31 @@ request.extendOptions({ timeout: 3000, params: { b: '2' }})
 
 当 options.getResponse === false 时, 响应结构为解析后的 data
 
-``` javascript
-request.get('/api/v1/xxx', { getResponse: false })
-  .then(function(data) {
-    console.log(data);
-  })
+```javascript
+request.get('/api/v1/xxx', { getResponse: false }).then(function(data) {
+  console.log(data);
+});
 ```
 
 当 options.getResponse === true 时，响应结构为包含 data 和 Response 的对象
 
-``` javascript
-request.get('/api/v1/xxx', { getResponse: true })
-  .then(function({ data, response }) {
-    console.log(data);
-    console.log(response.status);
-    console.log(response.statusText);
-    console.log(response.headers);
-  })
-
+```javascript
+request.get('/api/v1/xxx', { getResponse: true }).then(function({ data, response }) {
+  console.log(data);
+  console.log(response.status);
+  console.log(response.statusText);
+  console.log(response.headers);
+});
 ```
 
-在使用 catch 或者 errorHandler, 响应对象可以通过 ```error``` 对象获取使用，参考**错误处理**这一节文档。
+在使用 catch 或者 errorHandler, 响应对象可以通过 `error` 对象获取使用，参考**错误处理**这一节文档。
 
 ## 错误处理
 
-``` javascript
+```javascript
 import request, { extend } from 'umi-request';
 
-const errorHandler = function (error) {
+const errorHandler = function(error) {
   const codeMap = {
     '021': '发生错误啦',
     '022': '发生大大大大错误啦',
@@ -435,18 +435,17 @@ const errorHandler = function (error) {
     console.log(error.response.headers);
     console.log(error.data);
     console.log(error.request);
-    console.log(codeMap[error.data.status])
-    
+    console.log(codeMap[error.data.status]);
   } else {
     // 请求初始化时出错或者没有响应返回的异常
     console.log(error.message);
   }
 
-  throw error;   // 如果throw. 错误将继续抛出.
-  
+  throw error; // 如果throw. 错误将继续抛出.
+
   // 如果return, 则将值作为返回. 'return;' 相当于return undefined, 在处理结果时判断response是否有值即可.
-  // return {some: 'data'}; 
-}
+  // return {some: 'data'};
+};
 
 // 1. 作为统一错误处理
 const extendRequest = extend({ errorHandler });
@@ -454,18 +453,15 @@ const extendRequest = extend({ errorHandler });
 // 2. 单独特殊处理, 如果配置了统一处理, 但某个api需要特殊处理. 则在请求时, 将errorHandler作为参数传入.
 request('/api/v1/xxx', { errorHandler });
 
-
 // 3. 通过 Promise.catch 做错误处理
 request('/api/v1/xxx')
-.then(function (response) {
-  console.log(response);
-})
-.catch(function (error) {
-  return errorHandler(error);
-})
-
+  .then(function(response) {
+    console.log(response);
+  })
+  .catch(function(error) {
+    return errorHandler(error);
+  });
 ```
-
 
 ## 中间件
 
@@ -483,85 +479,91 @@ request.use(fn[, options])
 
 fn 入参
 
-* ctx(Object)：上下文对象，包括req和res对象
-* next(Function)：调用下一个中间件的函数
+- ctx(Object)：上下文对象，包括 req 和 res 对象
+- next(Function)：调用下一个中间件的函数
 
 options 参数
 
-* global(boolean): 是否为全局中间件，优先级比 core 高
-* core(boolean): 是否为内核中间件
+- global(boolean): 是否为全局中间件，优先级比 core 高
+- core(boolean): 是否为内核中间件
 
 ### 例子
 
 1. 同类型中间件执行顺序
 
-``` javascript
+```javascript
 import request, { extend } from 'umi-request';
 request.use(async (ctx, next) => {
   console.log('a1');
   await next();
   console.log('a2');
-})
+});
 request.use(async (ctx, next) => {
   console.log('b1');
   await next();
   console.log('b2');
-})
+});
 
 const data = await request('/api/v1/a');
 ```
 
 执行顺序如下：
 
-``` shell
+```shell
 a1 -> b1 -> response -> b2 -> a2
 ```
 
 2. 不同类型中间件执行顺序
 
-``` javascript
-request.use( async (ctx, next) => {
+```javascript
+request.use(async (ctx, next) => {
   console.log('instanceA1');
   await next();
   console.log('instanceA2');
-})
-request.use( async (ctx, next) => {
+});
+request.use(async (ctx, next) => {
   console.log('instanceB1');
   await next();
   console.log('instanceB2');
-})
-request.use( async (ctx, next) => {
-  console.log('globalA1');
-  await next();
-  console.log('globalA2');
-}, { global: true })
-request.use( async (ctx, next) => {
-  console.log('coreA1');
-  await next();
-  console.log('coreA2');
-}, { core: true })
+});
+request.use(
+  async (ctx, next) => {
+    console.log('globalA1');
+    await next();
+    console.log('globalA2');
+  },
+  { global: true }
+);
+request.use(
+  async (ctx, next) => {
+    console.log('coreA1');
+    await next();
+    console.log('coreA2');
+  },
+  { core: true }
+);
 ```
 
 执行顺序如下：
 
-``` shell
+```shell
 instanceA1 -> instanceB1 -> globalA1 -> coreA1 -> coreA2 -> globalA2 -> instanceB2 -> instanceA2
 ```
 
 3. 使用中间件对请求前后做处理
 
-``` javascript
+```javascript
 request.use(async (ctx, next) => {
   const { req } = ctx;
   const { url, options } = req;
 
   // 判断是否需要添加前缀，如果是统一添加可通过 prefix、suffix 参数配置
-  if ( url.indexOf('/api') !== 0 ) {
+  if (url.indexOf('/api') !== 0) {
     ctx.req.url = `/api/v1/${url}`;
   }
   ctx.req.options = {
     ...options,
-    foo: 'foo'
+    foo: 'foo',
   };
 
   await next();
@@ -571,78 +573,75 @@ request.use(async (ctx, next) => {
   if (!success) {
     // 对异常情况做对应处理
   }
-})
-
+});
 ```
 
 4. 使用内核中间件拓展请求能力
 
-``` javascript
+```javascript
+request.use(
+  async (ctx, next) => {
+    const { req } = ctx;
+    const { url, options } = req;
+    const { __umiRequestCoreType__ = 'normal' } = options;
 
-request.use(async (ctx, next) => {
-  const { req } = ctx;
-  const { url, options } = req;
-  const { __umiRequestCoreType__ = 'normal' } = options;
-  
-  // __umiRequestCoreType__ 用于区分请求内核类型
-  // 值为 'normal' 使用 umi-request 内置的请求内核
-  if ( __umiRequestCoreType__ === 'normal') {
+    // __umiRequestCoreType__ 用于区分请求内核类型
+    // 值为 'normal' 使用 umi-request 内置的请求内核
+    if (__umiRequestCoreType__ === 'normal') {
+      await next();
+      return;
+    }
+
+    // 非 normal 使用自定义请求内核获取响应数据
+    const response = getResponseByOtherWay();
+
+    // 将响应数据写入 ctx 中
+    ctx.res = response;
+
     await next();
     return;
-  }
-
-  // 非 normal 使用自定义请求内核获取响应数据
-  const response = getResponseByOtherWay();
-
-  // 将响应数据写入 ctx 中
-  ctx.res = response;
-
-  await next();
-  return;
-}, { core: true });
-
+  },
+  { core: true }
+);
 
 // 使用自定义请求内核
 request('/api/v1/rpc', {
   __umiRequestCoreType__: 'rpc',
   parseResponse: false,
 })
-  .then(function (response) {
+  .then(function(response) {
     console.log(response);
   })
-  .catch(function (error) {
+  .catch(function(error) {
     console.log(error);
-  })
-
+  });
 ```
 
 ## 拦截器
 
-在请求或响应被 ```then``` 或 ```catch``` 处理前拦截它们。
+在请求或响应被 `then` 或 `catch` 处理前拦截它们。
 
 1. 全局拦截器
 
-``` javascript
+```javascript
 // request拦截器, 改变url 或 options.
 request.interceptors.request.use((url, options) => {
-  return (
-    {
-      url: `${url}&interceptors=yes`,
-      options: { ...options, interceptors: true },
-    }
-  );
+  return {
+    url: `${url}&interceptors=yes`,
+    options: { ...options, interceptors: true },
+  };
 });
 
 // 和上一个相同
-request.interceptors.request.use((url, options) => {
-  return (
-    {
+request.interceptors.request.use(
+  (url, options) => {
+    return {
       url: `${url}&interceptors=yes`,
       options: { ...options, interceptors: true },
-    }
-  );
-}, { global: true });
-
+    };
+  },
+  { global: true }
+);
 
 // response拦截器, 处理response
 request.interceptors.response.use((response, options) => {
@@ -651,7 +650,7 @@ request.interceptors.response.use((response, options) => {
 });
 
 // 提前对响应做异常处理
-request.interceptors.response.use((response) => {
+request.interceptors.response.use(response => {
   const codeMaps = {
     502: '网关错误。',
     503: '服务不可用，服务器暂时过载或维护。',
@@ -662,29 +661,32 @@ request.interceptors.response.use((response) => {
 });
 
 // 克隆响应对象做解析处理
-request.interceptors.response.use(async (response) => {
+request.interceptors.response.use(async response => {
   const data = await response.clone().json();
-  if(data && data.NOT_LOGIN) {
+  if (data && data.NOT_LOGIN) {
     location.href = '登录url';
   }
   return response;
-})
+});
 ```
 
 2. 实例内部拦截器
 
-``` javascript
+```javascript
 // 全局拦截器直接使用 request 实例中的方法
-request.interceptors.request.use((url, options) => {
-  return {
-    url: `${url}&interceptors=yes`,
-    options: { ...options, interceptors: true },
-  };
-}, { global: false }); // 第二个参数不传默认为 { global: true }
+request.interceptors.request.use(
+  (url, options) => {
+    return {
+      url: `${url}&interceptors=yes`,
+      options: { ...options, interceptors: true },
+    };
+  },
+  { global: false }
+); // 第二个参数不传默认为 { global: true }
 
 function createClient(baseUrl) {
   const request = extend({
-    prefix: baseUrl
+    prefix: baseUrl,
   });
   return request;
 }
@@ -692,24 +694,31 @@ function createClient(baseUrl) {
 const clientA = createClient('/api');
 const clientB = createClient('/api');
 // 局部拦截器使用
-clientA.interceptors.request.use((url, options) => {
-  return {
-    url: `${url}&interceptors=clientA`,
-    options,
-  };
-}, { global: false });
+clientA.interceptors.request.use(
+  (url, options) => {
+    return {
+      url: `${url}&interceptors=clientA`,
+      options,
+    };
+  },
+  { global: false }
+);
 
-clientB.interceptors.request.use((url, options) => {
-  return {
-    url: `${url}&interceptors=clientB`,
-    options,
-  };
-}, { global: false });
+clientB.interceptors.request.use(
+  (url, options) => {
+    return {
+      url: `${url}&interceptors=clientB`,
+      options,
+    };
+  },
+  { global: false }
+);
 ```
 
 ## 取消请求
 
 你可以通过 **cancel token** 来取消一个请求
+
 > cancel token API 是基于已被撤销的 [cancelable-promises 方案](https://github.com/tc39/proposal-cancelable-promises)
 
 1. 你可以通过 **CancelToken.source** 来创建一个 cancel token，如下所示:
@@ -721,7 +730,7 @@ const CancelToken = Request.CancelToken;
 const { token, cancel } = CancelToken.source();
 
 Request.get('/api/cancel', {
-  cancelToken: token
+  cancelToken: token,
 }).catch(function(thrown) {
   if (Request.isCancel(thrown)) {
     console.log('Request canceled', thrown.message);
@@ -730,15 +739,18 @@ Request.get('/api/cancel', {
   }
 });
 
-Request.post('/api/cancel', {
-  name: 'hello world'
-}, {
-  cancelToken: token
-})
+Request.post(
+  '/api/cancel',
+  {
+    name: 'hello world',
+  },
+  {
+    cancelToken: token,
+  }
+);
 
 // 取消请求(参数为非必填)
 cancel('Operation canceled by the user.');
-
 ```
 
 2. 你也可以通过实例化 CancelToken 来创建一个 token，同时通过传入函数来获取取消方法：
@@ -752,10 +764,31 @@ let cancel;
 Request.get('/api/cancel', {
   cancelToken: new CancelToken(function executor(c) {
     cancel = c;
-  })
+  }),
 });
 // 取消请求
 cancel();
+```
+
+3. 通过 AbortCOntroller 取消
+
+```javascript
+import Request, { AbortController } from 'umi-request';
+
+const controller = new AbortController();
+const { signal } = controller;
+
+signal.addEventListener('abort', () => {
+  console.log('aborted!');
+});
+
+Request('http://127.0.0.1:3009/', {
+  signal,
+});
+// 取消请求
+setTimeout(() => {
+  controller.abort();
+}, 1000);
 ```
 
 ## 案例
@@ -764,21 +797,20 @@ cancel();
 
 通过 **Headers.get()** 获取响应头信息。(可参考 [MDN 文档](https://developer.mozilla.org/zh-CN/docs/Web/API/Headers/get))
 
-``` javascript
-request('/api/v1/some/api', { getResponse: true })
-.then(({ data, response}) => {
+```javascript
+request('/api/v1/some/api', { getResponse: true }).then(({ data, response }) => {
   response.headers.get('Content-Type');
-})
+});
 ```
 
 ### 文件上传
 
-使用 FormData() 构造函数时，浏览器会自动识别并添加请求头 ```"Content-Type: multipart/form-data"```, 且参数依旧是表单提交时那种键值对，因此不需要开发者手动设置 **Content-Type**
+使用 FormData() 构造函数时，浏览器会自动识别并添加请求头 `"Content-Type: multipart/form-data"`, 且参数依旧是表单提交时那种键值对，因此不需要开发者手动设置 **Content-Type**
 
-``` javascript
+```javascript
 const formData = new FormData();
 formData.append('file', file);
-request('/api/v1/some/api', { method:'post', data: formData });
+request('/api/v1/some/api', { method: 'post', data: formData });
 ```
 
 如果希望获取自定义头部信息，需要在服务器设置 [Access-Control-Expose-Headers](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Headers/Access-Control-Expose-Headers),然后可按照上述方式获取自定义头部信息。

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "isomorphic-fetch": "^2.2.1",
     "qs": "^6.9.1"
   },

--- a/src/cancel/abortControllerCancel.js
+++ b/src/cancel/abortControllerCancel.js
@@ -1,0 +1,3 @@
+import AbortController from 'abort-controller';
+
+export default AbortController;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import request, { extend, fetch } from './request';
 import Onion from './onion';
 import { RequestError, ResponseError } from './utils';
+import AbortController from './cancel/abortControllerCancel';
 
-export { extend, RequestError, ResponseError, Onion, fetch };
+export { extend, RequestError, ResponseError, Onion, fetch, AbortController };
 export default request;


### PR DESCRIPTION



umi-request cancel 的取消没有真正的取消

[Demo 前端代码](https://codesandbox.io/s/stupefied-hellman-9vzzd)

Demo 服务端代码
```js
var express = require("express");
var app = express();

app.get("/", function(req, res) {
  setTimeout(() => {
    res.send("Hello World!");
  }, 3000);
});

app.listen(3009, function() {
  console.log("Example app listening on port 3000!");
});

```
通过 AbortController 取消请求

![通过AbortController的取消请求](https://user-images.githubusercontent.com/28481035/70790796-be388680-1dd0-11ea-964f-9d8308802622.png)

通过 umi-request 内置取消请求

![umi 默认的取消请求](https://user-images.githubusercontent.com/28481035/70790938-02c42200-1dd1-11ea-9d21-8cf62a8adaec.png)

