### PR TITLE
OnionMiddleware 的 next 应该是返回一个 Promise

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,7 +76,7 @@ export interface Context {
 
 export type ResponseInterceptor = (response: Response, options: RequestOptionsInit) => Response | Promise<Response>;
 
-export type OnionMiddleware = (ctx: Context, next: () => void) => void;
+export type OnionMiddleware = (ctx: Context, next: () => Promise<void>) => void;
 export type OnionOptions = { global?: boolean; core?: boolean; defaultInstance?: boolean };
 
 export interface RequestMethod<R = false> {


### PR DESCRIPTION
OnionMiddleware 的 next 应该是返回一个 Promise，这样在 ts 中 await 时就不会提示`'await' has no effect on the type of this expression.ts(80007)`