### PR TITLE
Fix `content-type: multipart/form-data` causing requests to fail.

### DIFF
--- a/src/middleware/simplePost.js
+++ b/src/middleware/simplePost.js
@@ -1,4 +1,4 @@
-import { reqStringify } from '../utils';
+import { reqStringify, isFormData } from '../utils';
 
 // 对请求参数做处理，实现 query 简化、 post 简化
 export default function simplePostMiddleware(ctx, next) {
@@ -38,6 +38,10 @@ export default function simplePostMiddleware(ctx, next) {
       };
       options.body = data;
     }
+  }
+
+  if (isFormData(options.body)) {
+    delete options.headers['Content-Type'];
   }
   ctx.req.options = options;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -156,6 +156,10 @@ export function isObject(val) {
   return val !== null && typeof val === 'object';
 }
 
+export function isFormData(val) {
+  return (typeof FormData !== 'undefined') && (val instanceof FormData);
+}
+
 export function forEach2ObjArr(target, callback) {
   if (!target) return;
 


### PR DESCRIPTION
对于 `content-type: multipart/form-data` 的请求，需要删除请求头里的 `content-type`，让浏览器自己去添加，否则会由于未包含 `boundary` 信息，导致上传失败

见：
- https://github.com/umijs/umi-request/issues/98
- https://muffinman.io/uploading-files-using-fetch-multipart-form-data/