### PR TITLE
fix: upgrade isomorphic-fetch@3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "whatwg-fetch": "^3.0.0"
   },
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
+    "isomorphic-fetch": "^3.0.0",
     "qs": "^6.9.1"
   },
   "files": [


### PR DESCRIPTION
升级 isomorphic-fetch 版本为 3.0.0 将 node-fetch 依赖版本升级为 2.6.7 ，修复 node-fetch (< 2.6.7) 漏洞 CVE-2022-0235
http://horus.oa.com/advisory/HOSA-h0oi-ipysan7q4

@sorrycc 